### PR TITLE
Use ISO 8601'ish date

### DIFF
--- a/public/js/datetime-picker.js
+++ b/public/js/datetime-picker.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
   $('#inputDate').datetimepicker({
     sideBySide: true,
-    format: 'MM-DD-YYYY hh:mma',
+    format: 'YYYY-MM-DD hh:mma',
   });
   $('#selectTimeZone').chosen();
 });

--- a/routes/appointments.js
+++ b/routes/appointments.js
@@ -39,7 +39,7 @@ router.post('/', function(req, res, next) {
   const phoneNumber = req.body.phoneNumber;
   const notification = req.body.notification;
   const timeZone = req.body.timeZone;
-  const time = moment(req.body.time, 'MM-DD-YYYY hh:mma');
+  const time = moment(req.body.time, 'YYYY-MM-DD hh:mma');
 
   const appointment = new Appointment({
     name: name,
@@ -71,7 +71,7 @@ router.post('/:id/edit', function(req, res, next) {
   const phoneNumber = req.body.phoneNumber;
   const notification = req.body.notification;
   const timeZone = req.body.timeZone;
-  const time = moment(req.body.time, 'MM-DD-YYYY hh:mma');
+  const time = moment(req.body.time, 'YYYY-MM-DD hh:mma');
 
   Appointment.findOne({ _id: id }).then(function(appointment) {
     appointment.name = name;

--- a/test/appoinment.spec.js
+++ b/test/appoinment.spec.js
@@ -54,7 +54,7 @@ describe('appointment', function() {
         .send({
           name: 'Appointment',
           phoneNumber: '+5555555',
-          time: '02-17-2016 12:00am',
+          time: '2016-02-17 12:00am',
           notification: 15,
           timeZone: 'Africa/Algiers',
         })
@@ -94,7 +94,7 @@ describe('appointment', function() {
           .send({
             name: 'Appointment2',
             phoneNumber: '+66666666',
-            time: '02-17-2016 12:00am',
+            time: '2016-02-17 12:00am',
             notification: 15,
             timeZone: 'Africa/Algiers',
           })

--- a/views/appointments/_form.pug
+++ b/views/appointments/_form.pug
@@ -11,7 +11,7 @@
 .form-group
   label.col-sm-4.control-label(for='time') Appointment Date
   .col-sm-8
-    input#inputDate.form-control(type='text', name='time', placeholder='Pick a Date', required='', value=moment(appointment.time).format('MM-DD-YYYY hh:mma'))
+    input#inputDate.form-control(type='text', name='time', placeholder='Pick a Date', required='', value=moment(appointment.time).format('YYYY-MM-DD hh:mma'))
     em The date and time of the appointment.
 .form-group
   label.col-sm-4.control-label(for='selectNotification') Notification Time *


### PR DESCRIPTION
Fixes #32 

I use the term 'ish, because what this mostly
brings; is string-sort / natsort.

2012-01-17 02:45PM will come before
2012-01-18 02:45PM

AM should also come before PM and it's
largest unit to smallest.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
