### PR TITLE
Add custom appointment notification before time

### DIFF
--- a/views/appointments/_form.pug
+++ b/views/appointments/_form.pug
@@ -18,6 +18,7 @@
   .col-sm-8
     select#selectDelta.form-control(name='notification', required='', value=appointment.notification)
       option(selected=appointment.notification == '', value='') Send alert before
+      option(selected=appointment.notification == '2', value='2') 2 minutes before
       option(selected=appointment.notification == '15', value='15') 15 minutes before
       option(selected=appointment.notification == '30', value='30') 30 minutes before
       option(selected=appointment.notification == '45', value='45') 45 minutes before


### PR DESCRIPTION
Fixes #30 

Adds select element for 2 minutes prior notification

I don't actually suggest this merges; but it does answer the question

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
