### PR TITLE
Display notification expectated time in Listing

### DIFF
--- a/views/appointments/index.pug
+++ b/views/appointments/index.pug
@@ -7,7 +7,7 @@ block content
           th Name
           th Phone Number
           th Appointment time (UTC)
-          th Notification Time (minutes)
+          th Notification time (UTC)
           th Time Zone
           th Actions
           th
@@ -16,8 +16,8 @@ block content
           tr
             td  !{appointment.name}
             td  !{appointment.phoneNumber}
-            td  !{appointment.time}
-            td  !{appointment.notification}
+            td  #{moment(appointment.time).format('MM-DD-YYYY hh:mma')}
+            td  #{moment(appointment.time).subtract(appointment.notification, 'minutes').format('MM-DD-YYYY hh:mma')}
             td  !{appointment.timeZone}
             td
               a.btn.btn-default.btn-sm(href="/appointments/" + appointment.id + "/edit") Edit


### PR DESCRIPTION
Fixes #29 

Adds display of time notification expected to be sent to listing view.

Also formats the time (although still advises UTC)

I'm mostly having fun playing with pug. Never heard of it, not sure I'd use it, but it's interesting.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
