### PR TITLE
Display notification expectated time in Listing

### DIFF
--- a/test/appoinment.spec.js
+++ b/test/appoinment.spec.js
@@ -12,7 +12,7 @@ describe('appointment', function() {
     appointment = new Appointment({
       name: 'Appointment',
       phoneNumber: '+5555555',
-      time: new Date(),
+      time: '2016-02-17 12:00:00',
       notification: 15,
       timeZone: 'Africa/Algiers',
     });
@@ -27,7 +27,8 @@ describe('appointment', function() {
           .expect(function(response) {
             expect(response.text).to.contain('Appointment');
             expect(response.text).to.contain('+5555555');
-            expect(response.text).to.contain('15');
+            expect(response.text).to.contain('2016-02-17 12:00pm');
+            expect(response.text).to.contain('2016-02-17 11:45am');
             expect(response.text).to.contain('Africa/Algiers');
           })
           .expect(200, done);

--- a/views/appointments/index.pug
+++ b/views/appointments/index.pug
@@ -7,7 +7,7 @@ block content
           th Name
           th Phone Number
           th Appointment time (UTC)
-          th Notification Time (minutes)
+          th Notification time (UTC)
           th Time Zone
           th Actions
           th
@@ -16,8 +16,8 @@ block content
           tr
             td  !{appointment.name}
             td  !{appointment.phoneNumber}
-            td  !{appointment.time}
-            td  !{appointment.notification}
+            td  #{moment(appointment.time).format('YYYY-MM-DD hh:mma')}
+            td  #{moment(appointment.time).subtract(appointment.notification, 'minutes').format('YYYY-MM-DD hh:mma')}
             td  !{appointment.timeZone}
             td
               a.btn.btn-default.btn-sm(href="/appointments/" + appointment.id + "/edit") Edit


### PR DESCRIPTION
Fixes #29 Fixes #35 Reverts #36 

Adds display of time notification expected to be sent to listing view.

Also formats the time (although still advises UTC)

I'm mostly having fun playing with pug. Never heard of it, not sure I'd use it, but it's interesting.

Apologies for the prior commit failing. For some reason tests were passing locally even though they should not have been. I made sure I was seeing read before running to confirm green this time. Small enought I'll miss the refactor though 😉 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
