### PR TITLE
Fix strict equality issue and add time to appointment in message

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -24,7 +24,7 @@ function requiresNotification(appointment, currentTime) {
             .diff(moment(currentTime).utc())
         )
         .asMinutes()
-    ) === appointment.notification
+    ) === parseInt(appointment.notification, 10)
   );
 }
 
@@ -39,7 +39,7 @@ async function sendNotification(appointment) {
     to: `+ ${appointment.phoneNumber}`,
     from: cfg.twilioPhoneNumber,
     /* eslint-disable max-len */
-    body: `Hi ${appointment.name}. Just a reminder that you have an appointment coming up.`,
+    body: `Hi ${appointment.name}. Just a reminder that you have an appointment coming up in ${appointment.notification} minutes.`,
     /* eslint-enable max-len */
   };
 


### PR DESCRIPTION
When trying out this demo I noticed that I wasn't receiving any appointment notifications. It appears that the strict equals on L27 of notifications.js will never evaluate to be true because `appointment.notification` is always returned as a string while Math will return an int.

I also added the number of minutes until the appointment in the message body just for fun.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
